### PR TITLE
Fix url comment typo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -126,7 +126,7 @@ export default {
       });
     },
     // This builds a URI to get an access token from YNAB
-    // https://api.ynab.com/#outh-applications
+    // https://api.ynab.com/#oauth-applications
     authorizeWithYNAB(e) {
       e.preventDefault();
       const uri = `https://app.ynab.com/oauth/authorize?client_id=${this.ynab.clientId}&redirect_uri=${this.ynab.redirectUri}&response_type=token`;


### PR DESCRIPTION
Link to oauth part of docs was misspelled in the function comment