### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/gh-deploy.yaml
+++ b/.github/workflows/gh-deploy.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out the content of the repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Install Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: "Install dependencies, then build output JS bundle"
@@ -23,7 +23,7 @@ jobs:
           cp -pR ./dist ./public
       - name: Deploy to 'gh-pages' branch
         id: deploy-with-token
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- Pins all third-party GitHub Actions to full commit SHAs instead of
  mutable version tags (e.g., `actions/checkout@v4` →
  `actions/checkout@34e114876b0b... # v4`)
- Original version tags are preserved as comments for readability
- This is a security best practice recommended by GitHub to prevent
  supply chain attacks where a tag could be moved to point to
  malicious code

## Test plan
- [ ] Verify CI workflows still pass with pinned SHAs