### PR TITLE
Update Socket Basics job call path

### DIFF
--- a/.github/workflows/socket-basics.yml
+++ b/.github/workflows/socket-basics.yml
@@ -6,10 +6,7 @@ on:
 
 jobs:
   socket-basics-security-scan:
-    # We intentionally run this shared action from @main, not from a pinned sha
-    # this is because we control the shared-actions repo, so there is not a significant risk of malicious changes being pushed.
-    # Plus, the shared action does use pinned dependencies, and so will be updated fairly often.  When we do that, we do not
-    # want to have to update the sha in every repo that uses this shared action, before such updates apply.
-    uses: ynab/shared-actions/.github/workflows/socket-basics.yml@main
+    uses: ynab/ynab-sast-scanner/.github/workflows/socket-basics.yml@main
     secrets:
       SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+      SAST_SUPPRESSIONS_APP_PRIVATE_KEY: ${{ secrets.SAST_SUPPRESSIONS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Migrates this repo's Socket Basics CI scan to the new `ynab-sast-scanner` / `ynab-sast-scanner-suppressions` split — a public repo for the scanning mechanism, a private repo for suppression policy.

Changes to `.github/workflows/socket-basics.yml`:
- `uses:` now points to `ynab/ynab-sast-scanner/.github/workflows/socket-basics.yml@main`
- Added the `SAST_SUPPRESSIONS_APP_PRIVATE_KEY` secret
- Removed a stale comment about `shared-actions` that no longer applies here
