### PR TITLE
Socket Basics: Restore the @main-vs-pinned-sha rationale comment

### DIFF
--- a/.github/workflows/socket-basics.yml
+++ b/.github/workflows/socket-basics.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   socket-basics-security-scan:
+    # We intentionally run this shared action from @main, not from a pinned sha
+    # this is because we control the ynab-sast-scanner repo, so there is not a significant risk of malicious changes being pushed.
+    # Plus, the shared action does use pinned dependencies, and so will be updated fairly often.  When we do that, we do not
+    # want to have to update the sha in every repo that uses this shared action, before such updates apply.
     uses: ynab/ynab-sast-scanner/.github/workflows/socket-basics.yml@main
     secrets:
       SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}


### PR DESCRIPTION
Related PR: #100 

The previous PR to this branch/file already merged. This is a fresh PR that just adds back the @main-vs-pinned-sha comment in `.github/workflows/socket-basics.yml`, per Grant's review feedback on the original migration.